### PR TITLE
private書いただけね

### DIFF
--- a/chapter6/symphony.rb
+++ b/chapter6/symphony.rb
@@ -1,0 +1,113 @@
+require 'date'
+
+# お客さんをモデリングしたクラス
+class User
+  attr_accessor :name, :age
+
+  def initialize
+    puts 'ユーザー登録を行います'
+    puts 'ユーザー名を入力してください'
+    @name = gets.chomp
+    puts '年齢を入力してください'
+    @age = gets.chomp.to_i
+  end
+end
+
+# アトラクションをモデリングしたクラス
+class Ride
+  attr_reader :name, :fee
+
+  def initialize(name, fee)
+    @name = name
+    @fee = fee
+  end
+end
+
+# チケットをモデリングしたクラス
+class Ticket
+  attr_reader :ride, :date
+
+  def initialize(ride)
+    @ride = ride
+    @date = Date.today
+  end
+end
+
+# 券売機をモデリングしたクラス
+class TicketVendingSystem
+  attr_reader :user, :tickets
+
+  def initialize(user, tickets)
+    @user = user
+    @tickets = tickets
+  end
+
+  # 販売機能実行
+  def exec_transaction
+    puts '0. チケットを購入する'
+    puts '1. 終了'
+    num = gets.chomp.to_i
+    if num == 0
+      transaction
+    elsif num == 1
+      exit
+    else
+      puts '不正な入力です'
+    end
+  end
+
+  private
+
+  # チケット購入機能
+  def transaction
+    display_tickets
+    ticket = issue_ticket
+    run_payment(ticket)
+  end
+
+  # チケット一覧表示機能
+  def display_tickets
+    puts '購入したいチケットを以下から選んで、金額を入力してください'
+    tickets.ride.each_with_index do |ticket, i|
+      puts "[#{i}] 商品名：#{ticket.name} 価格：#{ticket.fee}"
+    end
+  end
+
+  # チケット発券機能
+  def issue_ticket
+    ticket = tickets.ride[gets.to_i]
+    puts "#{ticket.name}が選択されました"
+    ticket
+  end
+
+  # 決済処理
+  def run_payment(ticket)
+    puts 'お金をいれてください'
+    while true
+      payment = gets.to_i
+      charge = calc_change(payment, ticket.fee)
+
+      if charge >= 0
+        break
+      else
+        puts '入力金額が不足しています。金額を再入力してください。'
+      end
+    end
+
+    puts "お釣りは#{charge}円です。ご利用ありがとうございました。"
+  end
+
+  # お釣り算出機能
+  def calc_change(payment, fee)
+    payment - fee
+  end
+end
+
+rides = [
+  { name: 'roller coaster', fee: 1200 },
+  { name: 'merry-go-round', fee: 1000 },
+  { name: 'jackie coaster', fee: 800 }
+]
+
+rides_info = rides.map { |b| Ride.new(b[:name], b[:fee]) }
+TicketVendingSystem.new(User.new, Ticket.new(rides_info)).exec_transaction


### PR DESCRIPTION
## 概要
オブジェクト指向カリキュラム 6章で使用するソースコードです。

## 前提
カリキュラム内では、以下のような流れで実装します。

### 課題
TicketVendingSystemクラスは厳密には単一責任の原則を守ることが出来ていません。
TicketVendingSystemクラスの責務は「チケット発券」です。しかし、以下のような機能がTicketVendingSystemクラスの処理として定義されています。

- お釣り算出機能
- 決済処理機能

本来はそれぞれクラスを分けることが設計上好ましいです。ただ、この段階の設計規模で分けることは良い判断とはいえません。なぜなら、一目で機能が網羅できるコード量なので、違反していることを理解できデメリットに繋がる可能性が低いためです。


### 課題に対するアクション
「お釣り算出機能」と「決済処理機能」のメソッドをプライベートメソッドにして、TicketVendingSystemクラスを「チケットを発券する」という責務だけにします。

このように実装することで、「お釣り算出機能」と「決済処理機能」はパブリックインターフェースとならないため、TicketVendingSystemクラスは『チケットを販売する』という責務だけにできる。


## 実装内容
前章のコードに`private`を追記した。これにより、exec_transaction以外のメソッドがプライベートメソッドになる。

```ruby
 # 販売機能実行
  def exec_transaction
    puts '0. チケットを購入する'
    puts '1. 終了'
    num = gets.chomp.to_i
    if num == 0
      transaction
    elsif num == 1
      exit
    else
      puts '不正な入力です'
    end
  end

  private # ←追記

  # チケット購入機能
  def transaction
```


## レビュー依頼内容
- カリキュラムで説明するソースコードの雛形として、適切であるか
- 不要な省略はないか
- 冗長なコードはないか